### PR TITLE
Dockerfile cleanup

### DIFF
--- a/.ubuntu-security-tools.conf
+++ b/.ubuntu-security-tools.conf
@@ -2,7 +2,7 @@
 # https://github.com/zer0uid/docker-CVEanalysis
 # 
 # list of all active releases (included devel)
-release_list="precise trusty xenial bionic focal groovy hirsute"
+release_list="trusty xenial bionic focal groovy hirsute"
 
 # name of the current devel release
 # see https://wiki.ubuntu.com/SecurityTeam/ReleaseCycle for schedule

--- a/.vimrc
+++ b/.vimrc
@@ -1,0 +1,4 @@
+set syntax=on
+
+autocmd BufNewFile,BufRead CVE-[0-9][0-9][0-9][0-9]-[0-9]\\\{4,\} set syntax=cve
+autocmd BufNewFile,BufRead 00boilerplate.* set syntax=cve

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,15 +15,18 @@ SHELL ["/bin/bash", "-c"]
 
 # Install required packages [100%]
 RUN apt-get update 
-RUN apt-get install --assume-yes curl vim wget python3 python3-configobj python3-yaml python3-genshi python3-progressbar git rsync libfile-rsyncp-perl w3m debian-archive-keyring python3-apt python3-requests python3-distro-info apt-utils dpkg-dev
+RUN apt-get install --assume-yes git
 
 # Configure git-pulls directory, this is where CVE, QA, and Security Tools will reside [100%]
 RUN mkdir /root/git-pulls
 
 # Clone the required tools into /git-pulls [100%]
+RUN git -C /root/git-pulls clone https://salsa.debian.org/security-tracker-team/security-tracker.git
 RUN git -C /root/git-pulls clone git://git.launchpad.net/ubuntu-cve-tracker
 RUN git -C /root/git-pulls clone git://git.launchpad.net/ubuntu-qa-tools
 RUN git -C /root/git-pulls clone git://git.launchpad.net/ubuntu-security-tools
+
+RUN apt-get install --assume-yes curl vim wget python3 python3-configobj python3-yaml python3-genshi python3-progressbar git rsync libfile-rsyncp-perl w3m debian-archive-keyring python3-apt python3-requests python3-distro-info apt-utils dpkg-dev
 
 # Set variables for each tool
 RUN echo 'export UCT="/root/git-pulls/ubuntu-cve-tracker"' >> /root/.bashrc
@@ -35,8 +38,6 @@ COPY .ubuntu-cve-tracker.conf /root/
 COPY .ubuntu-security-tools.conf /root/
 RUN ln -s /root/git-pulls/ubuntu-security-tools/build-tools/umt /bin/umt
 
-# Clone security-tracker, this takes awhile
-RUN git -C /root/git-pulls clone https://salsa.debian.org/security-tracker-team/security-tracker.git
 RUN /root/git-pulls/ubuntu-cve-tracker/scripts/fetch-db database.pickle.bz2
 RUN /root/git-pulls/ubuntu-security-tools/build-tools/build-sources-list | sh -c 'cat > /etc/apt/sources.list.d/ubuntu-security.list'
 RUN cp /usr/share/keyrings/debian-archive-keyring.gpg /etc/apt/trusted.gpg.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,7 +44,6 @@ COPY .ubuntu-cve-tracker.conf /root/
 COPY .ubuntu-security-tools.conf /root/
 RUN ln -s $UST/build-tools/umt /bin/umt
 
-RUN $UCT/scripts/fetch-db database.pickle.bz2
 
 RUN $UST/build-tools/build-sources-list | sh -c 'cat > /etc/apt/sources.list.d/ubuntu-security.list'
 RUN cp /usr/share/keyrings/debian-archive-keyring.gpg /etc/apt/trusted.gpg.d/

--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,6 @@ RUN echo 'export UQT="/root/git-pulls/ubuntu-qa-tools"' >> /root/.bashrc
 COPY .ubuntu-cve-tracker.conf /root/
 COPY .ubuntu-security-tools.conf /root/
 RUN ln -s /root/git-pulls/ubuntu-security-tools/build-tools/umt /bin/umt
-RUN /root/git-pulls/ubuntu-cve-tracker/scripts/packages-mirror
 
 # Clone security-tracker, this takes awhile
 RUN git -C /root/git-pulls clone https://salsa.debian.org/security-tracker-team/security-tracker.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,33 +13,38 @@ SHELL ["/bin/bash", "-c"]
 # May need this after testing, which will give a login shell, so .bashrc is sourced for every command
 # SHELL ["/bin/bash", "-c", "-l"]
 
+ENV GIT=/root/git-pulls
+ENV UCT=$GIT/ubuntu-cve-tracker
+ENV UST=$GIT/ubuntu-security-tools
+
 # Install required packages [100%]
 RUN apt-get update 
 RUN apt-get install --assume-yes git
 
 # Configure git-pulls directory, this is where CVE, QA, and Security Tools will reside [100%]
-RUN mkdir /root/git-pulls
+RUN mkdir $GIT
 
 # Clone the required tools into /git-pulls [100%]
-RUN git -C /root/git-pulls clone https://salsa.debian.org/security-tracker-team/security-tracker.git
-RUN git -C /root/git-pulls clone git://git.launchpad.net/ubuntu-cve-tracker
-RUN git -C /root/git-pulls clone git://git.launchpad.net/ubuntu-qa-tools
-RUN git -C /root/git-pulls clone git://git.launchpad.net/ubuntu-security-tools
+RUN git -C $GIT clone https://salsa.debian.org/security-tracker-team/security-tracker.git
+RUN git -C $GIT clone git://git.launchpad.net/ubuntu-cve-tracker
+RUN git -C $GIT clone git://git.launchpad.net/ubuntu-qa-tools
+RUN git -C $GIT clone git://git.launchpad.net/ubuntu-security-tools
 
 RUN apt-get install --assume-yes curl vim wget python3 python3-configobj python3-yaml python3-genshi python3-progressbar git rsync libfile-rsyncp-perl w3m debian-archive-keyring python3-apt python3-requests python3-distro-info apt-utils dpkg-dev
 
-# Set variables for each tool
-RUN echo 'export UCT="/root/git-pulls/ubuntu-cve-tracker"' >> /root/.bashrc
-RUN echo 'export UST="/root/git-pulls/ubuntu-security-tools"' >> /root/.bashrc
-RUN echo 'export UQT="/root/git-pulls/ubuntu-qa-tools"' >> /root/.bashrc
+RUN echo 'export UCT=$UCT' >> /root/.bashrc
+RUN echo 'export UST=$UST' >> /root/.bashrc
+RUN echo 'export UQT="$GIT/ubuntu-qa-tools"' >> /root/.bashrc
 
 # Pull .conf files from github repo
 COPY .ubuntu-cve-tracker.conf /root/
 COPY .ubuntu-security-tools.conf /root/
-RUN ln -s /root/git-pulls/ubuntu-security-tools/build-tools/umt /bin/umt
+RUN ln -s $UST/build-tools/umt /bin/umt
 
-RUN /root/git-pulls/ubuntu-cve-tracker/scripts/fetch-db database.pickle.bz2
-RUN /root/git-pulls/ubuntu-security-tools/build-tools/build-sources-list | sh -c 'cat > /etc/apt/sources.list.d/ubuntu-security.list'
+RUN $UCT/scripts/fetch-db database.pickle.bz2
+
+RUN $UST/build-tools/build-sources-list | sh -c 'cat > /etc/apt/sources.list.d/ubuntu-security.list'
 RUN cp /usr/share/keyrings/debian-archive-keyring.gpg /etc/apt/trusted.gpg.d/
+
 RUN apt-get update
 RUN echo "....BUILD COMPLETE..."

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,10 @@ RUN git -C $GIT clone git://git.launchpad.net/ubuntu-cve-tracker
 RUN git -C $GIT clone git://git.launchpad.net/ubuntu-qa-tools
 RUN git -C $GIT clone git://git.launchpad.net/ubuntu-security-tools
 
-RUN apt-get install --assume-yes curl vim wget python3 python3-configobj python3-yaml python3-genshi python3-progressbar git rsync libfile-rsyncp-perl w3m debian-archive-keyring python3-apt python3-requests python3-distro-info apt-utils dpkg-dev
+RUN apt-get install --assume-yes curl vim wget python3 python3-configobj \
+    python3-yaml python3-genshi python3-progressbar git rsync \
+    libfile-rsyncp-perl w3m debian-archive-keyring python3-apt python3-requests \
+    python3-distro-info apt-utils dpkg-dev
 
 RUN echo 'export UCT=$UCT' >> /root/.bashrc
 RUN echo 'export UST=$UST' >> /root/.bashrc

--- a/Dockerfile
+++ b/Dockerfile
@@ -31,8 +31,8 @@ RUN echo 'export UST="/root/git-pulls/ubuntu-security-tools"' >> /root/.bashrc
 RUN echo 'export UQT="/root/git-pulls/ubuntu-qa-tools"' >> /root/.bashrc
 
 # Pull .conf files from github repo
-RUN wget https://raw.githubusercontent.com/zer0uid/docker-CVEanalysis/main/.ubuntu-cve-tracker.conf -P /root/
-RUN wget https://raw.githubusercontent.com/zer0uid/docker-CVEanalysis/main/.ubuntu-security-tools.conf -P /root/
+COPY .ubuntu-cve-tracker.conf /root/
+COPY .ubuntu-security-tools.conf /root/
 RUN ln -s /root/git-pulls/ubuntu-security-tools/build-tools/umt /bin/umt
 RUN /root/git-pulls/ubuntu-cve-tracker/scripts/packages-mirror
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ SHELL ["/bin/bash", "-c"]
 
 # Install required packages [100%]
 RUN apt-get update 
-RUN apt-get install --assume-yes curl vim wget python3 python3-configobj python3-yaml python3-genshi python3-progressbar git rsync libfile-rsyncp-perl w3m debian-archive-keyring python3-apt python3-requests python3-distro-info apt-utils
+RUN apt-get install --assume-yes curl vim wget python3 python3-configobj python3-yaml python3-genshi python3-progressbar git rsync libfile-rsyncp-perl w3m debian-archive-keyring python3-apt python3-requests python3-distro-info apt-utils dpkg-dev
 
 # Configure git-pulls directory, this is where CVE, QA, and Security Tools will reside [100%]
 RUN mkdir /root/git-pulls

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,4 +49,9 @@ RUN $UST/build-tools/build-sources-list | sh -c 'cat > /etc/apt/sources.list.d/u
 RUN cp /usr/share/keyrings/debian-archive-keyring.gpg /etc/apt/trusted.gpg.d/
 
 RUN apt-get update
+
+RUN mkdir -p $HOME/.vim/syntax
+RUN ln -s $UCT/scripts/cve.vim $HOME/.vim/syntax/cve.vim
+COPY .vimrc /root/
+
 RUN echo "....BUILD COMPLETE..."


### PR DESCRIPTION
Use ENV variables to clean up Dockerfile
Clone repositories as early as possible to expedite development
Remove unnecessary actions from Dockerfile
Add VIM syntax highlighting
Use local files instead of wget to expedite development
Remove precise from release_list